### PR TITLE
Double-tap to retry load added

### DIFF
--- a/app/src/main/java/com/jparkie/aizoban/presenters/ChapterPresenterOfflineImpl.java
+++ b/app/src/main/java/com/jparkie/aizoban/presenters/ChapterPresenterOfflineImpl.java
@@ -63,6 +63,7 @@ public class ChapterPresenterOfflineImpl implements ChapterPresenter {
     private boolean mIsLockOrientation;
     private boolean mIsLockZoom;
     private boolean mShowPageNumber;
+    private boolean mIsDoubleTapReloadEnabled;
 
     private boolean mInitialized;
     private int mInitialPosition;
@@ -108,10 +109,12 @@ public class ChapterPresenterOfflineImpl implements ChapterPresenter {
         mIsLockOrientation = PreferenceUtils.isLockOrientation();
         mIsLockZoom = PreferenceUtils.isLockZoom();
         mShowPageNumber = PreferenceUtils.hidePageNumber();
+        mIsDoubleTapReloadEnabled = PreferenceUtils.isDoubleTapReloadEnabled();
 
         mChapterMapper.applyIsLockOrientation(mIsLockOrientation);
         mChapterMapper.applyIsLockZoom(mIsLockZoom);
         mChapterMapper.setHidePageNumber(mShowPageNumber);
+        mChapterMapper.setIsDoubleTapReloadEnabled(mIsDoubleTapReloadEnabled);
     }
 
     @Override

--- a/app/src/main/java/com/jparkie/aizoban/presenters/ChapterPresenterOnlineImpl.java
+++ b/app/src/main/java/com/jparkie/aizoban/presenters/ChapterPresenterOnlineImpl.java
@@ -58,6 +58,7 @@ public class ChapterPresenterOnlineImpl implements ChapterPresenter {
     private boolean mIsLockOrientation;
     private boolean mIsLockZoom;
     private boolean mShowPageNumber;
+    private boolean mIsDoubleTapReloadEnabled;
 
     private boolean mInitialized;
     private int mInitialPosition;
@@ -105,10 +106,12 @@ public class ChapterPresenterOnlineImpl implements ChapterPresenter {
         mIsLockOrientation = PreferenceUtils.isLockOrientation();
         mIsLockZoom = PreferenceUtils.isLockZoom();
         mShowPageNumber = PreferenceUtils.hidePageNumber();
+        mIsDoubleTapReloadEnabled = PreferenceUtils.isDoubleTapReloadEnabled();
 
         mChapterMapper.applyIsLockOrientation(mIsLockOrientation);
         mChapterMapper.applyIsLockZoom(mIsLockZoom);
         mChapterMapper.setHidePageNumber(mShowPageNumber);
+        mChapterMapper.setIsDoubleTapReloadEnabled(mIsDoubleTapReloadEnabled);
     }
 
     @Override

--- a/app/src/main/java/com/jparkie/aizoban/presenters/mapper/ChapterMapper.java
+++ b/app/src/main/java/com/jparkie/aizoban/presenters/mapper/ChapterMapper.java
@@ -13,6 +13,8 @@ public interface ChapterMapper {
 
     public void setHidePageNumber(boolean hidePageNumber);
 
+    public void setIsDoubleTapReloadEnabled(boolean isDoubleTapReloadEnabled);
+
     public void applyIsLockOrientation(boolean isLockOrientation);
 
     public void applyIsLockZoom(boolean isLockZoom);

--- a/app/src/main/java/com/jparkie/aizoban/utils/PreferenceUtils.java
+++ b/app/src/main/java/com/jparkie/aizoban/utils/PreferenceUtils.java
@@ -127,6 +127,13 @@ public class PreferenceUtils {
         return sharedPreferences.getBoolean(context.getString(R.string.preference_chapter_order_key), false);
     }
 
+    public static boolean isDoubleTapReloadEnabled() {
+        Context context = AizobanApplication.getInstance();
+
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+        return sharedPreferences.getBoolean(context.getString(R.string.preference_double_tap_reload_key), false);
+    }
+
     public static boolean isExternalStorage() {
         Context context = AizobanApplication.getInstance();
 

--- a/app/src/main/java/com/jparkie/aizoban/views/activities/ChapterActivity.java
+++ b/app/src/main/java/com/jparkie/aizoban/views/activities/ChapterActivity.java
@@ -59,6 +59,7 @@ public class ChapterActivity extends BaseActivity implements ChapterView, Chapte
 
     private boolean mSystemUIVisibility;
     private boolean mHidePageNumber;
+    private boolean mIsDoubleTapReloadEnabled;
 
     public static Intent constructOnlineChapterActivityIntent(Context context, RequestWrapper chapterRequest, int position) {
         Intent argumentIntent = new Intent(context, ChapterActivity.class);
@@ -294,6 +295,15 @@ public class ChapterActivity extends BaseActivity implements ChapterView, Chapte
                         enableFullscreen();
                     } else {
                         disableFullscreen();
+                    }
+                }
+            });
+
+            mViewPager.setOnChapterDoubleTapListener(new GestureViewPager.OnChapterDoubleTapListener() {
+                @Override
+                public void onDoubleTap() {
+                    if (mIsDoubleTapReloadEnabled) {
+                        mChapterPresenter.onOptionRefresh();
                     }
                 }
             });
@@ -553,6 +563,11 @@ public class ChapterActivity extends BaseActivity implements ChapterView, Chapte
     @Override
     public void setHidePageNumber(boolean hidePageNumber) {
         mHidePageNumber = hidePageNumber;
+    }
+
+    @Override
+    public void setIsDoubleTapReloadEnabled(boolean isDoubleTapReloadEnabled) {
+        mIsDoubleTapReloadEnabled = isDoubleTapReloadEnabled;
     }
 
     @Override

--- a/app/src/main/java/com/jparkie/aizoban/views/widgets/GestureViewPager.java
+++ b/app/src/main/java/com/jparkie/aizoban/views/widgets/GestureViewPager.java
@@ -26,6 +26,7 @@ public class GestureViewPager extends ViewPager {
 
     private OnChapterBoundariesOutListener mOnChapterBoundariesOutListener;
     private OnChapterSingleTapListener mOnChapterSingleTapListener;
+    private OnChapterDoubleTapListener mOnChapterDoubleTapListener;
 
     public GestureViewPager(Context context) {
         super(context);
@@ -143,6 +144,10 @@ public class GestureViewPager extends ViewPager {
         mOnChapterSingleTapListener = onChapterSingleTapListener;
     }
 
+    public void setOnChapterDoubleTapListener(OnChapterDoubleTapListener onChapterDoubleTapListener) {
+        mOnChapterDoubleTapListener = onChapterDoubleTapListener;
+    }
+
     public interface OnChapterBoundariesOutListener {
         public void onFirstPageOut();
 
@@ -151,6 +156,10 @@ public class GestureViewPager extends ViewPager {
 
     public interface OnChapterSingleTapListener {
         public void onSingleTap();
+    }
+
+    public interface OnChapterDoubleTapListener {
+        public void onDoubleTap();
     }
 
     private class ImageViewGestureListener implements GestureDetector.OnGestureListener, GestureDetector.OnDoubleTapListener {
@@ -164,6 +173,8 @@ public class GestureViewPager extends ViewPager {
                         mGestureImageView.zoomToPoint(mGestureImageView.MAX_SCALE, motionEvent.getX(), motionEvent.getY());
                     }
                 }
+            } else {
+                mOnChapterDoubleTapListener.onDoubleTap();
             }
 
             return true;

--- a/app/src/main/res/values/preferences.xml
+++ b/app/src/main/res/values/preferences.xml
@@ -95,6 +95,9 @@
     <string name="preference_chapter_order_key">preference_chapter_order_key</string>
     <string name="preference_chapter_order_title">Ascending chapter order</string>
     <string name="preference_chapter_order_summary">Enable ascending chapter order</string>
+    <string name="preference_double_tap_reload_key">preference_double_tap_reload_key</string>
+    <string name="preference_double_tap_reload_title">Double-tap to refresh</string>
+    <string name="preference_double_tap_reload_summary">Double-tap to refresh/retry when the image failed</string>
 
     <!-- Download: -->
     <string name="preference_download_wifi_key">preference_download_wifi</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -67,6 +67,11 @@
             android:title="@string/preference_chapter_order_title"
             android:summary="@string/preference_chapter_order_summary"
             android:defaultValue="false"/>
+        <CheckBoxPreference
+            android:key="@string/preference_double_tap_reload_key"
+            android:title="@string/preference_double_tap_reload_title"
+            android:summary="@string/preference_double_tap_reload_summary"
+            android:defaultValue="false"/>
     </PreferenceCategory>
     <PreferenceCategory
         android:key="@string/preference_category_download_key"


### PR DESCRIPTION
Added preference to enable double-tap to retry load when the image has failed download. Defaults to false, will not affect previous installs.

Quality of life change, makes reading much much easier from poor hosts.